### PR TITLE
Support for multilingual user/author names

### DIFF
--- a/pages/ShibbolethHandler.inc.php
+++ b/pages/ShibbolethHandler.inc.php
@@ -370,8 +370,15 @@ class ShibbolethHandler extends Handler {
 		$user->setAuthStr($uin);
 		$user->setUsername($userEmail);
 		$user->setEmail($userEmail);
-		$user->setFirstName($userFirstName);
-		$user->setLastName($userLastName);
+
+		// Get the site primary locale, needed for setting the given name
+		// and family name of the user.
+		$request = Application::getRequest();
+		$site = $request->getSite();
+		$sitePrimaryLocale = $site->getPrimaryLocale();
+
+		$user->setGivenName($userFirstName, $sitePrimaryLocale);
+		$user->setFamilyName($userLastName, $sitePrimaryLocale);
 
 		if (!empty($userInitials)) {
 			$user->setInitials($userInitials);


### PR DESCRIPTION
* First gets the site primary locale and then sets the given name and
  last name of the user for that locale.