### PR TITLE
Remove unmatched button tag, reformat Shibboleth profile template

### DIFF
--- a/templates/shibbolethProfile.tpl
+++ b/templates/shibbolethProfile.tpl
@@ -16,12 +16,11 @@
 		<p>{$shibbolethDescription}</p>
 	{/if}
 	<a href="{$shibbolethLoginUrl}" class="cmp_button">
-			{if trim($shibbolethButtonLabel) != ""}
-				{$shibbolethButtonLabel}
-			{else}
-				{translate key="plugins.generic.shibboleth.manager.settings.InstitutionalLogin"}
-			{/if}
-		</button>
+		{if trim($shibbolethButtonLabel) != ""}
+			{$shibbolethButtonLabel}
+		{else}
+			{translate key="plugins.generic.shibboleth.manager.settings.InstitutionalLogin"}
+		{/if}
 	</a>
 </div>
 <h2>


### PR DESCRIPTION
There was an errant `</button>` in the code for this template, this PR cleans that up and un-indents the other code to match the rest of the file.